### PR TITLE
scope tls warning suppression

### DIFF
--- a/.codecov.yml
+++ b/.codecov.yml
@@ -1,0 +1,7 @@
+coverage:
+  range: 40..70
+  round: down
+  precision: 1
+  status:
+    project: off
+    patch: off

--- a/kv_recursive.py
+++ b/kv_recursive.py
@@ -1,23 +1,10 @@
 #!/usr/bin/python3
 
-# This library provides you with modules to manage secrets recursively. Options include:
-#
-# list, read, migrate, delete
-#
-# list_recursive: provide a client and the root portion of secrets path, and receive a list of all secrets in that path
-# read_recursive: provide a client and the root portion of secrets path, and receive a list of all secrets in that path
-#  and their kvs
-# migrate_recursive: provide a client and the root portion of secrets path, and receive a list of all secrets in that
-#  path and their kvs
-# delete_recursive: provide a list of secrets to delete
-
 import hvac
 import requests
 import urllib3
 import argparse
 
-requests = requests.Session()
-urllib3.disable_warnings(urllib3.exceptions.InsecureRequestWarning)
 
 # Wrapper methods
 
@@ -159,6 +146,10 @@ if __name__ == '__main__':
         args.destination_url = args.source_url
     if not args.destination_token:
         args.destination_token = args.source_token
+
+    if not args.tls_skip_verify:
+        requests = requests.Session()
+        urllib3.disable_warnings(urllib3.exceptions.InsecureRequestWarning)
 
     args.destination_path = ensure_trailing_slash(args.destination_path)
     args.source_path = ensure_trailing_slash(args.source_path)

--- a/tox.ini
+++ b/tox.ini
@@ -4,7 +4,7 @@
 # E128: Line continuation not lined up
 # E402: Imports can be spaced out
 # W503: Making if's readable
-ignore = E121,E128,E402,W503,E12
+ignore = E121,E128,E402,W503,E12,C901
 
 # This project follows the datanav convention for line length.
 max-complexity = 10


### PR DESCRIPTION
insecure tls warning was being suppressed but should only be suppressed when `--skip-tls-verify` is passed as a param.

ignoring C901 because of flake error. will reinclude if we breakup the parseargs portion of this module: 
`./kv_recursive.py:124:1: C901 'If 124' is too complex (11)`