### PR TITLE
Update docs to reflect source and destination kv versions

### DIFF
--- a/README.md
+++ b/README.md
@@ -57,18 +57,19 @@ The same works with `--destination-path` except the write will start at the path
 
 ## Arguments:
 
-| name                  | syntax                        |     default    | required? | choices                        | desc.                                                                          |
-|-----------------------|-------------------------------|:--------------:|:---------:|--------------------------------|--------------------------------------------------------------------------------|
-| action                |                               |      list      |     *     | copy, move, delete, list, read | action to perform                                                              |
-| skip tls verification | --tls-skip-verify             |                |           |                                |                                                                                |
-| source path           | --source-path, -s             |       ''       |     *     |                                | kv path to use as root for recursion lookup                                    |
-| source url            | --source-url, -su             |                |     *     |                                | FQDN of vault url with port where kvs are sourced from                         |
-| source token          | --source-token, -st           |                |     *     |                                | token used for read authorization in source vault                              |
-| source namespace      | --source-namespace, -sns      |       ''       |           |                                | namespace where kv resides. leave empty if kv mount is in root                 |
-| source mount          | --source-mount, -sm           |     secret     |           |                                | name of the kv mount to read from                                              |
-| destination path      | --destination-path, -d        |  --source-path |           |                                | kv path to use as root for recursion write. defaults to same as --source-path. |
-| destination url       | --destination-url, -du        |  --source-url  |           |                                | FQDN of vault url with port where kvs are written to. default is --source-url  |
-| destination token     | --destination-token, -dt      | --source-token |           |                                | token used for write authorization in source vault. default is --source-token  |
-| destination namespace | --destination-namespace, -dns |                |           |                                | namespace to write kvs. leave empty if kv mount is in root                     |
-| destination mount     | --destination-mount, -dm      |     secret     |           |                                | name of the kv mount to write to. default is same as --source-mount            |
-| kv version            | --kv-version, -kvv            |        1       |           |                                | which kv version secrets are stored as. will be written using same version     |
+| name                   | syntax                         |     default    | required? | choices                        | desc.                                                                          |
+|------------------------|--------------------------------|:--------------:|:---------:|--------------------------------|--------------------------------------------------------------------------------|
+| action                 |                                |      list      |     *     | copy, move, delete, list, read | action to perform                                                              |
+| skip tls verification  | --tls-skip-verify              |                |           |                                |                                                                                |
+| source path            | --source-path, -s              |       ''       |     *     |                                | kv path to use as root for recursion lookup                                    |
+| source url             | --source-url, -su              |                |     *     |                                | FQDN of vault url with port where kvs are sourced from                         |
+| source token           | --source-token, -st            |                |     *     |                                | token used for read authorization in source vault                              |
+| source namespace       | --source-namespace, -sns       |       ''       |           |                                | namespace where kv resides. leave empty if kv mount is in root                 |
+| source mount           | --source-mount, -sm            |     secret     |           |                                | name of the kv mount to read from                                              |
+| source kv version      | --source-kv-version, -skv      |        2       |           |                1, 2            | which source kv version secrets are stored as.                                 |
+| destination path       | --destination-path, -d         |  --source-path |           |                                | kv path to use as root for recursion write. defaults to same as --source-path. |
+| destination url        | --destination-url, -du         |  --source-url  |           |                                | FQDN of vault url with port where kvs are written to. default is --source-url  |
+| destination token      | --destination-token, -dt       | --source-token |           |                                | token used for write authorization in source vault. default is --source-token  |
+| destination namespace  | --destination-namespace, -dns  |                |           |                                | namespace to write kvs. leave empty if kv mount is in root                     |
+| destination mount      | --destination-mount, -dm       |     secret     |           |                                | name of the kv mount to write to. default is same as --source-mount            |
+| destination kv version | --destination-kv-version, -dkv |        2       |           |                1, 2            | which destination kv version secrets are stored as.                            |


### PR DESCRIPTION
release v1.1.0 added the ability to migrate to different versions of kv. AKA kvv1 -> kvv2 (or vice versa).

This PR updates docs to reflect those new arguments which was initially missed!